### PR TITLE
ci: add release automation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    # version tags are protected in this repository
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    # use an environment when releasing
+    environment: Publish
+
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # history is required to enable release notes generation
+          fetch-depth: 0
+
+      - name: Configure Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Release
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: v2.1.0
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+dist/
 docker-credential-env

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+builds:
+  - id: release
+    binary: docker-credential-env
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X "main.Version={{.Version}}" -X "main.Revision={{.FullCommit}}"'
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+checksum:
+  name_template: "checksums.txt"
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+
+changelog:
+  use: github-native
+  sort: asc
+
+release:
+  prerelease: auto
+  header: |
+    Distributions for this release are published as binaries below.
+
+    In order for Docker to be able to use the binary, it must be in the PATH, have the name `docker-credential-env`, and be executable by the required user. Note that it is sufficient to create an appropriately named symoblic link to make it discoverable by Docker.
+
+    Binaries are available for Mac, Linux and Windows.


### PR DESCRIPTION
Enables the use of GoReleaser to create binaries when a `v*` tag is created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an automated release workflow for the Go application, streamlining the release process.
	- Added configuration for GoReleaser to enhance binary building and release management for multiple platforms.
  
- **Chores**
	- Updated `.gitignore` to exclude the `dist/` directory from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->