### PR TITLE
fix: fail silently for unsupported actions

### DIFF
--- a/helper/env.go
+++ b/helper/env.go
@@ -30,18 +30,16 @@ func (e EnvHelper) Get(serverURL string) (string, string, error) {
 	logger.Info("Get", "user", user, "err", err)
 
 	return user, password, err
-
 }
 
 func (e EnvHelper) Add(creds *credentials.Credentials) error {
-
-	slog.Info("", "action", "add", "serverURL", creds.ServerURL, "username", creds.Username)
-	return ErrNotImplemented
+	slog.Warn("Saving credentials is not supported by docker-credential-env", "action", "add", "serverURL", creds.ServerURL, "username", creds.Username)
+	return nil
 }
 
 func (e EnvHelper) Delete(serverURL string) error {
-	slog.Info("", "action", "delete", "serverURL", serverURL)
-	return ErrNotImplemented
+	slog.Warn("Deleting credentials is not supported by docker-credential-env", "action", "delete", "serverURL", serverURL)
+	return nil
 }
 
 func (e EnvHelper) List() (map[string]string, error) {

--- a/helper/env_test.go
+++ b/helper/env_test.go
@@ -31,19 +31,19 @@ func TestEnvHelper_Get_Failure(t *testing.T) {
 	assert.Empty(t, password)
 }
 
-func TestEnvHelper_Add(t *testing.T) {
+func TestEnvHelper_Add_FailsSilently(t *testing.T) {
 	helper := EnvHelper{}
 	err := helper.Add(&credentials.Credentials{})
-	assert.ErrorIs(t, err, ErrNotImplemented)
+	assert.NoError(t, err)
 }
 
-func TestEnvHelper_Delete(t *testing.T) {
+func TestEnvHelper_Delete_FailsSilently(t *testing.T) {
 	helper := EnvHelper{}
 	err := helper.Delete("foo")
-	assert.ErrorIs(t, err, ErrNotImplemented)
+	assert.NoError(t, err)
 }
 
-func TestEnvHelper_List(t *testing.T) {
+func TestEnvHelper_List_NotImplemented(t *testing.T) {
 	helper := EnvHelper{}
 	_, err := helper.List()
 	assert.ErrorIs(t, err, ErrNotImplemented)

--- a/helper/env_test.go
+++ b/helper/env_test.go
@@ -21,6 +21,17 @@ func TestEnvHelper_Get_Success(t *testing.T) {
 	assert.Equal(t, "testpassword", password)
 }
 
+func TestEnvHelper_Get_CredentialsOptional_Success(t *testing.T) {
+
+	helper := EnvHelper{CredentialsOptional: true}
+
+	user, password, err := helper.Get("example.com")
+
+	assert.NoError(t, err)
+	assert.Empty(t, user)
+	assert.Empty(t, password)
+}
+
 func TestEnvHelper_Get_Failure(t *testing.T) {
 	helper := EnvHelper{}
 

--- a/main.go
+++ b/main.go
@@ -21,7 +21,9 @@ func main() {
 
 	configureLogging()
 
-	credentials.Serve(helper.EnvHelper{})
+	credentialsOptional := os.Getenv("DOCKER_CREDENTIALS_ENV_OPTIONAL") == "true"
+
+	credentials.Serve(helper.EnvHelper{CredentialsOptional: credentialsOptional})
 }
 
 func configureLogging() {


### PR DESCRIPTION
Credential storage makes little sense for a plugin based on environment variables.

Failure to store or delete is written as a warning, but will not fail the Docker process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced credential retrieval logic to conditionally handle errors based on a new optional credentials setting.
	- Updated logging for adding and deleting credentials to provide clearer warnings about unsupported functionalities.

- **Bug Fixes**
	- Refined test cases to reflect the expected silent failure behaviour for add and delete functions, ensuring no errors are raised.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->